### PR TITLE
Adding User-Agent header to github API calls as it is now enforced

### DIFF
--- a/docs/repositories_releases.js.html
+++ b/docs/repositories_releases.js.html
@@ -87,6 +87,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -115,6 +116,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -143,6 +145,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/latest'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -171,6 +174,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/tags/' + tag))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -199,6 +203,7 @@ module.exports = {
 			request
 				.post(getRepoUrl('releases'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -230,6 +235,7 @@ module.exports = {
 			request
 				.patch(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -260,6 +266,7 @@ module.exports = {
 			request
 				.delete(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -288,6 +295,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/' + releaseId + '/assets'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -376,6 +384,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -405,6 +414,7 @@ module.exports = {
 			request
 				.patch(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -435,6 +445,7 @@ module.exports = {
 			request
 				.delete(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);

--- a/src/repositories/releases.js
+++ b/src/repositories/releases.js
@@ -48,6 +48,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -76,6 +77,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -104,6 +106,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/latest'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -132,6 +135,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/tags/' + tag))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -160,6 +164,7 @@ module.exports = {
 			request
 				.post(getRepoUrl('releases'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -191,6 +196,7 @@ module.exports = {
 			request
 				.patch(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -221,6 +227,7 @@ module.exports = {
 			request
 				.delete(getRepoUrl('releases/' + releaseId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -249,6 +256,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/' + releaseId + '/assets'))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -337,6 +345,7 @@ module.exports = {
 			request
 				.get(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);
@@ -366,6 +375,7 @@ module.exports = {
 			request
 				.patch(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.set('Content-Type', 'application/json')
 				.send(body)
 				.then(function(res) {
@@ -396,6 +406,7 @@ module.exports = {
 			request
 				.delete(getRepoUrl('releases/assets/' + assetId))
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					logRequestSuccess(res);
 					deferred.resolve(res.body);

--- a/src/request-helpers.js
+++ b/src/request-helpers.js
@@ -84,6 +84,7 @@ module.exports = {
 			// Set standard stuff and handle response
 			req
 				.set('Authorization', 'token ' + config.token)
+				.set('User-Agent', 'github-api-promise')
 				.then(function(res) {
 					self.logRequestSuccess(res);
 					deferred.resolve({


### PR DESCRIPTION
API calls without a user-agent header return 403